### PR TITLE
Fix a TypeError

### DIFF
--- a/model_quantization.py
+++ b/model_quantization.py
@@ -35,7 +35,7 @@ def golomb_bits(v):
 
 def quantize_array(A, q):
     quant_A = (np.abs(A) * q).astype(np.int32)
-    quant_A *= np.sign(A)
+    quant_A *= np.sign(A).astype(np.int32)
 
     dequant_A = np.array(quant_A, dtype=np.float32)
     dequant_A += 0.5 * np.sign(quant_A)


### PR DESCRIPTION
Hi 

I faced the following error, when I used a "model_quantization.py" program.

```
TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int32') with casting rule 'same_kind'
```

So I added more cast operations and erased above error. 
