### PR TITLE
Fix binary search

### DIFF
--- a/model_quantization.py
+++ b/model_quantization.py
@@ -64,19 +64,23 @@ def quantize_array_lbda(A, lbda):
 def quantize_array_target(A, target_err):
     low = 1
     high = 128
+    mid = low
     A_norms = np.sqrt(np.sum(A**2, axis=-1))
 
-    while high - low > 1:
-        mid = (high + low) / 2
+    while low < high:
+        mid = low + (high - low) / 2
         quant_A, dequant_A = quantize_array(A, mid)
         mean_err = np.mean(np.sqrt(np.sum((dequant_A - A)**2, axis=-1)) / A_norms)
         logging.info("Binary search: q=%d, err=%.3f", mid, mean_err)
 
         if mean_err > target_err:
-            low = mid
+            low = mid + 1
         else:
             high = mid
-
+    mid = low
+    quant_A, dequant_A = quantize_array(A, mid)
+    mean_err = np.mean(np.sqrt(np.sum((dequant_A - A)**2, axis=-1)) / A_norms)
+    logging.info("Result: q=%d, err=%.3f", mid, mean_err)
     return mid, mean_err, quant_A, dequant_A
 
 


### PR DESCRIPTION
Basically we cannot reuse exit status (quant_A, mid) as final result, as the following log shows, current logic will produce quantized vector with `mean_err > target_error`.

Since there are log(N) candidate nodes in the search tree, It would be simpler / easier if we just calculate it in the last pass.

Log before fix:
https://gist.github.com/sleepsort/1d0d1582825c6ea248eca19a0a471d1f

Log after fix:
https://gist.github.com/sleepsort/64ac49af24dc98eefa3ea8c4575ab3b6

To reproduce:
- Before patching this commit, download additional patch with data: 
  https://gist.github.com/sleepsort/0585a47f42d200b1d445201e3d928474
- Run command:
  ./model_quantization.py quant test.w2v.txt /tmp/test.w2v
- Patch this commit
- Rerun the command to compare.
